### PR TITLE
Fixes critical rate formula in jalu14/oath-rocalc#3

### DIFF
--- a/src/foot.js
+++ b/src/foot.js
@@ -954,7 +954,7 @@ function StAllCalc() {
         n_A_LUCKY = Math.round(10 * n_A_LUCKY) / 10,
         n_A_LUCKY < 0 && (n_A_LUCKY = 0),
         myInnerHtml("A_LUCKY", n_A_LUCKY, 0),
-        n_A_CRI = 1 + .3 * n_A_LUK,
+        n_A_CRI = 1 + Math.floor( n_A_LUK / 3 );
         S = 0,
         S += n_tok[10] + n_A_Buf9[39],
         S += n_tok[110 + selectedMonster[2]],


### PR DESCRIPTION
Fixes critical rate formula in jalu14/oath-rocalc#3
Every LUK should now give ~0.33% CRIT, discarding decimals.